### PR TITLE
Fixed 1 issue of type: PYTHON_E251 throughout 1 file in repo.

### DIFF
--- a/colorpk/repository/db.py
+++ b/colorpk/repository/db.py
@@ -49,7 +49,7 @@ def deleteUserLike(colorId, userId):
         return True
 
 def getUserLike(userId):
-    list_like0 = UserLike.objects.filter(user_id = userId)
+    list_like0 = UserLike.objects.filter(user_id=userId)
     list_like1 = list(map(lambda x: model_to_dict(x)['color'], list_like0))
     return list_like1
 


### PR DESCRIPTION
PYTHON_E251: 'unexpected spaces around keyword / parameter equals'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.